### PR TITLE
feat: implement refresh token endpoint

### DIFF
--- a/sortArray/jwtauth/refresh.go
+++ b/sortArray/jwtauth/refresh.go
@@ -1,0 +1,62 @@
+package jwtauth
+
+import (
+	"github.com/golang-jwt/jwt"
+	"net/http"
+	"time"
+)
+
+func Refresh(w http.ResponseWriter, r *http.Request) {
+
+	c, err := r.Cookie("token")
+	if err != nil {
+		if err == http.ErrNoCookie {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	tknStr := c.Value
+	claims := &Claims{}
+	tkn, err := jwt.ParseWithClaims(tknStr, claims, func(token *jwt.Token) (interface{}, error) {
+		return jwtKey, nil
+	})
+	if err != nil {
+		if err == jwt.ErrSignatureInvalid {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if !tkn.Valid {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	// Ensure that a new token is not issued until enough time has elapsed
+	// In this case, a new token will only be issued if the old token is within
+	// 30 seconds of expiry. Otherwise, return a bad request status
+	if time.Unix(claims.ExpiresAt, 0).Sub(time.Now()) > 30*time.Second {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Now, create a new token for the current use, with a renewed expiration time
+	expirationTime := time.Now().Add(5 * time.Minute)
+	claims.ExpiresAt = expirationTime.Unix()
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString(jwtKey)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// Set the new token as the users `token` cookie
+	http.SetCookie(w, &http.Cookie{
+		Name:    "token",
+		Value:   tokenString,
+		Expires: expirationTime,
+	})
+}

--- a/sortArray/service/handler.go
+++ b/sortArray/service/handler.go
@@ -23,6 +23,7 @@ func RestController() {
 
 	myRouter.HandleFunc("/", HomePage)
 	myRouter.HandleFunc("/signin", jwtauth.SignIn).Methods("POST")
+	myRouter.HandleFunc("/refresh", jwtauth.Refresh).Methods("POST")
 	myRouter.HandleFunc("/api/v1/all", GetAllArrays).Methods("GET")
 	myRouter.HandleFunc("/api/v1/array/default", CreateNewArray(histogram)).Methods("POST")
 	myRouter.HandleFunc("/api/v1/array/{id}", GetArrayByID).Methods("GET")

--- a/sortArray/service/service.go
+++ b/sortArray/service/service.go
@@ -25,7 +25,7 @@ func CreateNewArray(histogram *prometheus.HistogramVec) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		err := jwtauth.AuthenticateWithJWT(w, r)
 		if err != nil {
-			log.Fatal(err.Error())
+			log.Println(err.Error())
 		}
 		start := time.Now()
 		code := 500


### PR DESCRIPTION
Implemented /refresh endpoint, when the token is about to elapse <30 sec a request to the /refresh endpoint will provide a new token.